### PR TITLE
Update manifest link in docs

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -3,7 +3,7 @@
 ## What's in this directory
 * `config/`: Webpack configuration for this project.
 * `public/`: Popup files.
-    * `manifest.json`: Extension [configuration](https://developer.chrome.com/docs/extensions/mv2/manifest/).
+    * `manifest.json`: Extension [configuration](https://developer.chrome.com/docs/extensions/mv3/manifest/).
 * `src/`: Source files for the popup, [background scripts](https://developer.chrome.com/docs/extensions/mv3/service_workers/#manifest), and [content scripts](https://developer.chrome.com/docs/extensions/mv3/content_scripts/).
 * `.gitignore`: Lists files to be ignored in your Git repo.
 * `package.json`: Contains project configuration, scripts, and dependencies.


### PR DESCRIPTION
## Summary
- fix the documentation link for manifest.json in `quickstart.md`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68409cea07d48324a01435c091c6caf6