### PR TITLE
Add ChatGPT summary request

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -18,6 +18,9 @@
     "tabs",
     "contextMenus"
   ],
+  "host_permissions": [
+    "https://api.openai.com/*"
+  ],
   "content_scripts": [
     {
       "matches": ["http://*/*", "https://*/*"],

--- a/public/popup.html
+++ b/public/popup.html
@@ -11,5 +11,6 @@
     <h1>Bem-vindo Ao ResumoGpt</h1>
     <button id="myButton">Clique aqui</button>
     <p id="pageTitle">Nada ainda</p>
+    <p id="summary"></p>
   </body>
 </html>

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -1,7 +1,6 @@
 chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
   if (message.action === 'getTitle') {
-    const pageTitle = document.title;
-    console.log(pageTitle);
-    chrome.runtime.sendMessage({ title: "todo o texto que peguei do whats app web" });
+    const selectedText = window.getSelection().toString();
+    chrome.runtime.sendMessage({ title: selectedText });
   }
 });

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -8,16 +8,44 @@ chrome.contextMenus.create({
 
 chrome.contextMenus.onClicked.addListener(teste);
 
+const API_TOKEN = 'YOUR_OPENAI_API_KEY';
+
+async function summarize(text: string) {
+  const summaryEl = document.getElementById('summary');
+  if (!text) return;
+  if (summaryEl) summaryEl.textContent = 'Resumindo...';
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${API_TOKEN}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: `Resuma o seguinte texto:\n\n${text}` }],
+      }),
+    });
+    const data = await response.json();
+    const resumo = data.choices?.[0]?.message?.content || 'Erro ao resumir.';
+    if (summaryEl) summaryEl.textContent = resumo;
+  } catch (err) {
+    console.error(err);
+    if (summaryEl) summaryEl.textContent = 'Erro ao conectar à API.';
+  }
+}
+
 function teste(data,tab){
   const page = document.getElementById('pageTitle');
-  page.textContent = data.selectionText;
+  page.textContent = data.selectionText || '';
+  summarize(data.selectionText || '');
 }
 
 chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
-  var pageTitle = message.title;
-  console.log(pageTitle);
+  const pageTitle = message.title;
   const page = document.getElementById('pageTitle');
   page.textContent = pageTitle;
+  summarize(pageTitle);
 });
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -35,6 +35,12 @@ async function summarize(text: string) {
       const resumo = data.choices?.[0]?.message?.content || 'Erro ao resumir.';
       if (summaryEl) summaryEl.textContent = resumo;
     });
+    if (!response.ok) {
+      const errorMessage = `Erro na API: ${response.status} ${response.statusText}`;
+      console.error(errorMessage);
+      if (summaryEl) summaryEl.textContent = 'Erro ao conectar à API.';
+      return;
+    }
   } catch (err) {
     console.error(err);
     if (summaryEl) summaryEl.textContent = 'Erro ao conectar à API.';


### PR DESCRIPTION
## Summary
- send selected text to ChatGPT in `popup.ts`
- show the returned summary in popup
- capture selected text from pages
- allow requests to api.openai.com

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68409d306478832486b8f9f2acf66d75