### PR TITLE
Add simple login flow

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -8,9 +8,17 @@
     <link rel="stylesheet" href="popup.css">
   </head>
   <body>
-    <h1>Bem-vindo Ao ResumoGpt</h1>
-    <button id="myButton">Clique aqui</button>
-    <p id="pageTitle">Nada ainda</p>
-    <p id="summary"></p>
+    <div id="login-container" style="display:none">
+      <h1>Login</h1>
+      <input type="password" id="tokenInput" placeholder="API Token" />
+      <button id="loginButton">Entrar</button>
+    </div>
+    <div id="app" style="display:none">
+      <h1>Bem-vindo Ao ResumoGpt</h1>
+      <button id="myButton">Clique aqui</button>
+      <p id="pageTitle">Nada ainda</p>
+      <p id="summary"></p>
+      <button id="logoutButton">Sair</button>
+    </div>
   </body>
 </html>

--- a/src/popup.css
+++ b/src/popup.css
@@ -20,6 +20,19 @@ body {
     background-color:#1B2244;
 }
 
+#login-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+}
+
+#login-container input {
+    margin-bottom: 10px;
+    padding: 5px;
+}
+
 .app {
     height: 100%;
     display: flex;

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -3,7 +3,7 @@ import './popup.css'
 chrome.contextMenus.create({
   title: 'Pad é frango',
   contexts: ['all'],
-  id: "1"
+  id: '1',
 });
 
 chrome.contextMenus.onClicked.addListener(teste);
@@ -47,7 +47,7 @@ async function summarize(text: string) {
   }
 }
 
-function teste(data,tab){
+function teste(data, tab) {
   const page = document.getElementById('pageTitle');
   page.textContent = data.selectionText || '';
   summarize(data.selectionText || '');
@@ -60,14 +60,54 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
   summarize(pageTitle);
 });
 
-document.addEventListener('DOMContentLoaded', function() {
-  var button = document.getElementById('myButton');
-  button.addEventListener('click', function() {
+document.addEventListener('DOMContentLoaded', function () {
+  const loginContainer = document.getElementById('login-container');
+  const appContainer = document.getElementById('app');
+  const loginButton = document.getElementById('loginButton');
+  const logoutButton = document.getElementById('logoutButton');
+  const tokenInput = document.getElementById('tokenInput') as HTMLInputElement;
+
+  function showLogin() {
+    if (loginContainer) loginContainer.style.display = 'block';
+    if (appContainer) appContainer.style.display = 'none';
+  }
+
+  function showApp() {
+    if (loginContainer) loginContainer.style.display = 'none';
+    if (appContainer) appContainer.style.display = 'block';
+  }
+
+  chrome.storage.local.get(['API_TOKEN'], function (result) {
+    if (result.API_TOKEN) {
+      showApp();
+    } else {
+      showLogin();
+    }
+  });
+
+  loginButton?.addEventListener('click', function () {
+    const token = tokenInput?.value || '';
+    if (!token) {
+      alert('Informe o token.');
+      return;
+    }
+    chrome.storage.local.set({ API_TOKEN: token }, function () {
+      showApp();
+    });
+  });
+
+  logoutButton?.addEventListener('click', function () {
+    chrome.storage.local.remove(['API_TOKEN'], function () {
+      showLogin();
+    });
+  });
+
+  const button = document.getElementById('myButton');
+  button?.addEventListener('click', function () {
     alert('Botão clicado!');
   });
 
-  // Solicita o título da página ao contentScript.js
-  chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
     chrome.tabs.sendMessage(tabs[0].id, { action: 'getTitle' });
   });
 });


### PR DESCRIPTION
## Summary
- add login form to popup.html
- style login UI and update popup.css
- store API token in chrome storage through popup.ts and require login

## Testing
- `npm run build` *(fails: cannot install packages)*

------
https://chatgpt.com/codex/tasks/task_e_6840a99b7afc8324ac62a94ae77fd45c