### PR TITLE
Add simple login and dashboard pages

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Dashboard</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Dashboard</h1>
+  <div id="info"></div>
+  <button id="logout">Logout</button>
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const infoEl = document.getElementById('info');
+  const logoutBtn = document.getElementById('logout');
+
+  chrome.storage.local.get('JWT_TOKEN', data => {
+    if (!data.JWT_TOKEN) {
+      window.location.href = 'popup.html';
+    } else {
+      infoEl.textContent = 'Logged in';
+    }
+  });
+
+  logoutBtn?.addEventListener('click', () => {
+    chrome.storage.local.remove('JWT_TOKEN', () => {
+      window.location.href = 'popup.html';
+    });
+  });
+});

--- a/public/popup.html
+++ b/public/popup.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Login</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="message"></div>
+  <div id="login">
+    <h1>Login</h1>
+    <input id="login-email" type="email" placeholder="Email">
+    <input id="login-password" type="password" placeholder="Password">
+    <button id="login-btn">Login</button>
+  </div>
+  <div id="register">
+    <h1>Register</h1>
+    <input id="register-username" type="text" placeholder="Username">
+    <input id="register-email" type="email" placeholder="Email">
+    <input id="register-password" type="password" placeholder="Password">
+    <button id="register-btn">Register</button>
+  </div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/public/popup.js
+++ b/public/popup.js
@@ -1,0 +1,66 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const loginBtn = document.getElementById('login-btn');
+  const registerBtn = document.getElementById('register-btn');
+  const messageEl = document.getElementById('message');
+
+  function showMessage(msg, success=false) {
+    if (!messageEl) return;
+    messageEl.textContent = msg;
+    messageEl.className = success ? 'success' : 'error';
+  }
+
+  loginBtn?.addEventListener('click', () => {
+    const email = document.getElementById('login-email').value;
+    const password = document.getElementById('login-password').value;
+
+    fetch('/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      mode: 'cors',
+      body: JSON.stringify({ email, password })
+    })
+      .then(r => r.json())
+      .then(data => {
+        if (data.token) {
+          chrome.storage.local.set({ JWT_TOKEN: data.token }, () => {
+            showMessage('Login successful', true);
+            setTimeout(() => {
+              window.location.href = 'dashboard.html';
+            }, 500);
+          });
+        } else {
+          showMessage(data.error || 'Login failed');
+        }
+      })
+      .catch(() => showMessage('Login failed'));
+  });
+
+  registerBtn?.addEventListener('click', () => {
+    const username = document.getElementById('register-username').value;
+    const email = document.getElementById('register-email').value;
+    const password = document.getElementById('register-password').value;
+
+    fetch('/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      mode: 'cors',
+      body: JSON.stringify({ username, email, password })
+    })
+      .then(r => r.json())
+      .then(data => {
+        if (data.token) {
+          chrome.storage.local.set({ JWT_TOKEN: data.token }, () => {
+            showMessage('Registered', true);
+            setTimeout(() => {
+              window.location.href = 'dashboard.html';
+            }, 500);
+          });
+        } else if (data.message) {
+          showMessage(data.message, true);
+        } else {
+          showMessage(data.error || 'Register failed');
+        }
+      })
+      .catch(() => showMessage('Register failed'));
+  });
+});

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,22 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 20px;
+}
+input {
+  display: block;
+  margin-bottom: 10px;
+  padding: 5px;
+}
+button {
+  padding: 5px 10px;
+  margin-bottom: 10px;
+}
+#message {
+  margin-bottom: 10px;
+}
+.success {
+  color: green;
+}
+.error {
+  color: red;
+}


### PR DESCRIPTION
## Summary
- add plain popup for login/registration
- add dashboard page with logout
- store JWT in chrome storage and redirect on success

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840fba6fef4832494607d77c49886e7