### PR TITLE
Update Chrome host permissions

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -26,7 +26,8 @@
     "type": "module"
   },
   "host_permissions": [
-    "https://api.openai.com/*"
+    "https://api.openai.com/*",
+    "http://localhost:3000/*"
   ]
 }
 


### PR DESCRIPTION
## Summary
- enable requests to the local backend API by listing `http://localhost:3000/*` in the extension's `manifest.json`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6840fba9f37c83249220caded3c7d405