### PR TITLE
Fix extension login/register URL

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -1,0 +1,4 @@
+(() => {
+  const isDevelopment = !('update_url' in chrome.runtime.getManifest());
+  window.API_BASE_URL = isDevelopment ? 'http://localhost:3000' : 'https://your-production-url.com';
+})();

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -9,6 +9,7 @@
   <h1>Dashboard</h1>
   <div id="info"></div>
   <button id="logout">Logout</button>
+  <script src="config.js"></script>
   <script src="dashboard.js"></script>
 </body>
 </html>

--- a/public/popup.html
+++ b/public/popup.html
@@ -20,6 +20,7 @@
     <input id="register-password" type="password" placeholder="Password">
     <button id="register-btn">Register</button>
   </div>
+  <script src="config.js"></script>
   <script src="popup.js"></script>
-</body>
+  </body>
 </html>

--- a/public/popup.js
+++ b/public/popup.js
@@ -3,9 +3,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const registerBtn = document.getElementById('register-btn');
   const messageEl = document.getElementById('message');
 
-  // Determine API base URL depending on environment
-  const isDev = !('update_url' in chrome.runtime.getManifest());
-  const API_BASE_URL = isDev ? 'http://localhost:3000' : 'https://your-production-url.com';
+  // API base URL provided by config.js
+  const { API_BASE_URL } = window;
 
   function showMessage(msg, success=false) {
     if (!messageEl) return;

--- a/public/popup.js
+++ b/public/popup.js
@@ -3,6 +3,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const registerBtn = document.getElementById('register-btn');
   const messageEl = document.getElementById('message');
 
+  // Determine API base URL depending on environment
+  const isDev = !('update_url' in chrome.runtime.getManifest());
+  const API_BASE_URL = isDev ? 'http://localhost:3000' : 'https://your-production-url.com';
+
   function showMessage(msg, success=false) {
     if (!messageEl) return;
     messageEl.textContent = msg;
@@ -13,7 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const email = document.getElementById('login-email').value;
     const password = document.getElementById('login-password').value;
 
-    fetch('/login', {
+    fetch(`${API_BASE_URL}/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       mode: 'cors',
@@ -40,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const email = document.getElementById('register-email').value;
     const password = document.getElementById('register-password').value;
 
-    fetch('/register', {
+    fetch(`${API_BASE_URL}/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       mode: 'cors',


### PR DESCRIPTION
## Summary
- use full API URL in popup.js for login and register
- add environment-based API URL detection

## Testing
- `npm run build` *(fails: Cannot find module 'webpack/bin/webpack.js')*

------
https://chatgpt.com/codex/tasks/task_e_684104fc33cc8324b175fc9fe217edf1