### PR TITLE
Add API key storage to dashboard

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -8,6 +8,9 @@
 <body>
   <h1>Dashboard</h1>
   <div id="info"></div>
+  <input id="api-key" type="text" placeholder="API Key">
+  <button id="save-api-key">Salvar API Key</button>
+  <div id="api-message"></div>
   <button id="logout">Logout</button>
   <script src="config.js"></script>
   <script src="dashboard.js"></script>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,6 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
   const infoEl = document.getElementById('info');
   const logoutBtn = document.getElementById('logout');
+  const apiInput = document.getElementById('api-key');
+  const saveApiBtn = document.getElementById('save-api-key');
+  const apiMessageEl = document.getElementById('api-message');
 
   chrome.storage.local.get('JWT_TOKEN', data => {
     if (!data.JWT_TOKEN) {
@@ -10,9 +13,25 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  chrome.storage.local.get('API_TOKEN', data => {
+    if (data.API_TOKEN && apiInput) {
+      apiInput.value = data.API_TOKEN;
+    }
+  });
+
   logoutBtn?.addEventListener('click', () => {
     chrome.storage.local.remove('JWT_TOKEN', () => {
       window.location.href = 'popup.html';
+    });
+  });
+
+  saveApiBtn?.addEventListener('click', () => {
+    const value = apiInput?.value || '';
+    chrome.storage.local.set({ API_TOKEN: value }, () => {
+      if (apiMessageEl) {
+        apiMessageEl.textContent = 'API Key salva com sucesso';
+        apiMessageEl.className = 'success';
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- allow users to save API token from dashboard
- show stored API key when page loads
- update dashboard HTML layout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68410a37453c83249b95b9c06591674b