### PR TITLE
Add Vite build config

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -14,7 +14,7 @@
     "default_popup": "popup.html"
   },
   "background": {
-    "service_worker": "background.js",
+    "service_worker": "background/index.js",
     "type": "module"
   },
   "permissions": [

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  build: {
+    outDir: 'build',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        popup: resolve(__dirname, 'public/popup.html'),
+        dashboard: resolve(__dirname, 'public/dashboard.html'),
+        background: resolve(__dirname, 'src/background/index.ts'),
+      },
+      output: {
+        entryFileNames: chunk => {
+          if (chunk.name === 'background') {
+            return 'background/index.js';
+          }
+          return '[name].js';
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add `vite.config.js` to build popup, dashboard and background script
- update `manifest.json` to reference new background output

## Testing
- `npm run build` *(fails: Cannot find module 'webpack')*

------
https://chatgpt.com/codex/tasks/task_e_68410d496704832488ea4915179b66a1