### PR TITLE
Add dashboard open button in popup

### DIFF
--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -46,6 +46,7 @@ function toggleForm() {
 
 function openDashboard() {
   chrome.tabs.create({ url: chrome.runtime.getURL('dashboard.html') })
+  window.close()
 }
 
 function login() {

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -6,6 +6,7 @@
     <input v-model="loginPassword" type="password" placeholder="Password" />
     <button @click="login">Login</button>
     <button @click="toggleForm">Cadastre-se</button>
+    <button v-if="loginSuccess" @click="openDashboard">Abrir Dashboard</button>
   </div>
   <div v-else>
     <h1>Register</h1>
@@ -31,6 +32,7 @@ const registerPassword = ref('')
 const message = ref('')
 const messageType = ref('')
 const isLogin = ref(true)
+const loginSuccess = ref(false)
 const router = useRouter()
 
 function showMessage(msg: string, success = false) {
@@ -40,6 +42,10 @@ function showMessage(msg: string, success = false) {
 
 function toggleForm() {
   isLogin.value = !isLogin.value
+}
+
+function openDashboard() {
+  chrome.tabs.create({ url: chrome.runtime.getURL('dashboard.html') })
 }
 
 function login() {
@@ -57,9 +63,7 @@ function login() {
       if (data.token) {
         chrome.storage.local.set({ JWT_TOKEN: data.token }, () => {
           showMessage('Login successful', true)
-          setTimeout(() => {
-            router.push('/dashboard.html')
-          }, 500)
+          loginSuccess.value = true
         })
       } else {
         showMessage(data.error || 'Login failed')


### PR DESCRIPTION
## Summary
- show an "Abrir Dashboard" button after a successful login
- call `chrome.tabs.create` from this button to open `dashboard.html`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684115a80e948324bd17c675ebd37288