### PR TITLE
Refactor forms to use BootstrapVue components

### DIFF
--- a/src/dashboard/App.vue
+++ b/src/dashboard/App.vue
@@ -1,10 +1,18 @@
 <template>
-  <h1>Dashboard</h1>
-  <div id="info">{{ info }}</div>
-  <input v-model="apiKey" id="api-key" type="text" placeholder="API Key" />
-  <button id="save-api-key" @click="saveApiKey">Salvar API Key</button>
-  <div id="api-message" class="success" v-if="apiMessage">{{ apiMessage }}</div>
-  <button id="logout" @click="logout">Logout</button>
+  <!-- BootstrapVue components unify the styling of inputs and buttons -->
+  <!-- BCard groups dashboard actions for a cleaner layout -->
+  <b-card>
+    <h1>Dashboard</h1>
+    <div id="info">{{ info }}</div>
+    <b-form-input v-model="apiKey" id="api-key" type="text" placeholder="API Key" class="mb-3" />
+    <!-- Actions aligned with Bootstrap utility classes -->
+    <div class="d-flex justify-content-between mb-3">
+      <!-- Variant colors draw attention to primary and destructive actions -->
+      <b-button id="save-api-key" variant="primary" @click="saveApiKey">Salvar API Key</b-button>
+      <b-button id="logout" variant="danger" @click="logout">Logout</b-button>
+    </div>
+    <div id="api-message" class="success" v-if="apiMessage">{{ apiMessage }}</div>
+  </b-card>
 </template>
 
 <script setup lang="ts">

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -1,21 +1,29 @@
 <template>
+  <!-- BootstrapVue inputs and buttons provide consistent styling and better accessibility -->
   <div id="message" :class="messageType" v-if="message">{{ message }}</div>
-  <div v-if="isLogin">
+  <!-- Using a BCard groups related fields with consistent padding and a subtle shadow, improving focus -->
+  <b-card v-if="isLogin" class="mb-3">
     <h1>Login</h1>
-    <input v-model="loginEmail" type="email" placeholder="Email" />
-    <input v-model="loginPassword" type="password" placeholder="Password" />
-    <button @click="login">Login</button>
-    <button @click="toggleForm">Cadastre-se</button>
-    <button v-if="loginSuccess" @click="openDashboard">Abrir Dashboard</button>
-  </div>
-  <div v-else>
+    <b-form-input v-model="loginEmail" type="email" placeholder="Email" class="mb-3" />
+    <b-form-input v-model="loginPassword" type="password" placeholder="Password" class="mb-3" />
+    <!-- Utility classes keep actions aligned and spaced -->
+    <div class="d-flex justify-content-between mb-3">
+      <b-button variant="primary" @click="login">Login</b-button>
+      <b-button variant="secondary" @click="toggleForm">Cadastre-se</b-button>
+    </div>
+    <b-button v-if="loginSuccess" variant="success" @click="openDashboard">Abrir Dashboard</b-button>
+  </b-card>
+  <b-card v-else class="mb-3">
     <h1>Register</h1>
-    <input v-model="registerUsername" type="text" placeholder="Username" />
-    <input v-model="registerEmail" type="email" placeholder="Email" />
-    <input v-model="registerPassword" type="password" placeholder="Password" />
-    <button @click="register">Register</button>
-    <button @click="toggleForm">Voltar ao login</button>
-  </div>
+    <b-form-input v-model="registerUsername" type="text" placeholder="Username" class="mb-3" />
+    <b-form-input v-model="registerEmail" type="email" placeholder="Email" class="mb-3" />
+    <b-form-input v-model="registerPassword" type="password" placeholder="Password" class="mb-3" />
+    <!-- Buttons share space evenly on small screens -->
+    <div class="d-flex justify-content-between">
+      <b-button variant="primary" @click="register">Register</b-button>
+      <b-button variant="secondary" @click="toggleForm">Voltar ao login</b-button>
+    </div>
+  </b-card>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary
- convert popup login/register forms to `<b-form-input>` and `<b-button>` components wrapped in `<b-card>`
- restyle dashboard screen with `<b-card>` and button variants
- add explanatory comments and Bootstrap utility classes

## Testing
- `npm install`
- `npm run build` *(fails: copy-static ENOENT manifest.json)*

------
https://chatgpt.com/codex/tasks/task_e_68411f341e8c8324bc1cce61ac23c4e6