### PR TITLE
Add Open Sans font to UI

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Dashboard</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
 </head>
 <body>
   <div id="app"></div>

--- a/public/popup.html
+++ b/public/popup.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Popup</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
 </head>
 <body>
   <div id="app"></div>

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -1,2 +1,6 @@
 @import 'variables';
 @import '~bootstrap/scss/bootstrap';
+
+body {
+  font-family: 'Open Sans', Arial, sans-serif;
+}


### PR DESCRIPTION
## Summary
- include Google Font link in popup and dashboard HTML
- set Open Sans as default body font in main stylesheet

## Testing
- `npm install`
- `npm run build` *(fails: copy-static ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68411f9826a4832481cf1896f29fac93