### PR TITLE
Fix vite build errors

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <div id="app"></div>
-  <script src="/config.js"></script>
+  <script type="module" src="./config.js"></script>
   <script type="module" src="/src/dashboard/main.ts"></script>
 </body>
 </html>

--- a/public/popup.html
+++ b/public/popup.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <div id="app"></div>
-  <script src="/config.js"></script>
+  <script type="module" src="./config.js"></script>
   <script type="module" src="/src/popup/main.ts"></script>
   </body>
 </html>

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -1,5 +1,5 @@
 @import 'variables';
-@import '~bootstrap/scss/bootstrap';
+@import 'bootstrap/scss/bootstrap';
 
 body {
   font-family: 'Open Sans', Arial, sans-serif;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';
-import { copyFileSync, cpSync, rmSync } from 'fs';
+import { copyFileSync, cpSync, rmSync, mkdirSync, existsSync } from 'fs';
 
 const htmlInputs = {
   popup: resolve(__dirname, 'public/popup.html'),
@@ -15,13 +15,23 @@ export default defineConfig({
     {
       name: 'copy-static',
       closeBundle() {
-        copyFileSync('public/manifest.json', 'build/manifest.json');
-        cpSync('public/icons', 'build/icons', { recursive: true });
-        copyFileSync('public/config.js', 'build/config.js');
+        copyFileSync(resolve(__dirname, 'public/manifest.json'),
+          resolve(__dirname, 'build/manifest.json'));
+        cpSync(resolve(__dirname, 'public/icons'),
+          resolve(__dirname, 'build/icons'), { recursive: true });
+        copyFileSync(resolve(__dirname, 'public/config.js'),
+          resolve(__dirname, 'build/config.js'));
         // move processed html from public directory to build root
-        copyFileSync('build/public/popup.html', 'build/popup.html');
-        copyFileSync('build/public/dashboard.html', 'build/dashboard.html');
-        rmSync('build/public', { recursive: true, force: true });
+        const popupHtml = resolve(__dirname, 'build/public/popup.html');
+        const dashboardHtml = resolve(__dirname, 'build/public/dashboard.html');
+        if (existsSync(popupHtml)) {
+          copyFileSync(popupHtml, resolve(__dirname, 'build/popup.html'));
+        }
+        if (existsSync(dashboardHtml)) {
+          copyFileSync(dashboardHtml, resolve(__dirname, 'build/dashboard.html'));
+        }
+        if (existsSync(resolve(__dirname, 'build/public')))
+          rmSync(resolve(__dirname, 'build/public'), { recursive: true, force: true });
       }
     }
   ],


### PR DESCRIPTION
## Summary
- treat `config.js` as module and use relative path
- fix Bootstrap import path
- ensure static copy plugin handles paths correctly and only removes the `build/public` folder if present

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841202de75c8324990ce840ec95cbec