### PR TITLE
Fix popup size in Chrome extension

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Dashboard</title>
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
 </head>

--- a/public/popup.html
+++ b/public/popup.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Popup</title>
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
 </head>

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -1,29 +1,31 @@
 <template>
-  <!-- BootstrapVue inputs and buttons provide consistent styling and better accessibility -->
-  <div id="message" :class="messageType" v-if="message">{{ message }}</div>
-  <!-- Using a BCard groups related fields with consistent padding and a subtle shadow, improving focus -->
-  <b-card v-if="isLogin" class="mb-3">
-    <h1>Login</h1>
-    <b-form-input v-model="loginEmail" type="email" placeholder="Email" class="mb-3" />
-    <b-form-input v-model="loginPassword" type="password" placeholder="Password" class="mb-3" />
-    <!-- Utility classes keep actions aligned and spaced -->
-    <div class="d-flex justify-content-between mb-3">
-      <b-button variant="primary" @click="login">Login</b-button>
-      <b-button variant="secondary" @click="toggleForm">Cadastre-se</b-button>
-    </div>
-    <b-button v-if="loginSuccess" variant="success" @click="openDashboard">Abrir Dashboard</b-button>
-  </b-card>
-  <b-card v-else class="mb-3">
-    <h1>Register</h1>
-    <b-form-input v-model="registerUsername" type="text" placeholder="Username" class="mb-3" />
-    <b-form-input v-model="registerEmail" type="email" placeholder="Email" class="mb-3" />
-    <b-form-input v-model="registerPassword" type="password" placeholder="Password" class="mb-3" />
-    <!-- Buttons share space evenly on small screens -->
-    <div class="d-flex justify-content-between">
-      <b-button variant="primary" @click="register">Register</b-button>
-      <b-button variant="secondary" @click="toggleForm">Voltar ao login</b-button>
-    </div>
-  </b-card>
+  <div class="popup-wrapper container mx-auto text-center p-3">
+    <!-- BootstrapVue inputs and buttons provide consistent styling and better accessibility -->
+    <div id="message" :class="messageType" v-if="message">{{ message }}</div>
+    <!-- Using a BCard groups related fields with consistent padding and a subtle shadow, improving focus -->
+    <b-card v-if="isLogin" class="mb-3">
+      <h1>Login</h1>
+      <b-form-input v-model="loginEmail" type="email" placeholder="Email" class="mb-3" />
+      <b-form-input v-model="loginPassword" type="password" placeholder="Password" class="mb-3" />
+      <!-- Utility classes keep actions aligned and spaced -->
+      <div class="d-flex justify-content-between mb-3">
+        <b-button variant="primary" @click="login">Login</b-button>
+        <b-button variant="secondary" @click="toggleForm">Cadastre-se</b-button>
+      </div>
+      <b-button v-if="loginSuccess" variant="success" @click="openDashboard">Abrir Dashboard</b-button>
+    </b-card>
+    <b-card v-else class="mb-3">
+      <h1>Register</h1>
+      <b-form-input v-model="registerUsername" type="text" placeholder="Username" class="mb-3" />
+      <b-form-input v-model="registerEmail" type="email" placeholder="Email" class="mb-3" />
+      <b-form-input v-model="registerPassword" type="password" placeholder="Password" class="mb-3" />
+      <!-- Buttons share space evenly on small screens -->
+      <div class="d-flex justify-content-between">
+        <b-button variant="primary" @click="register">Register</b-button>
+        <b-button variant="secondary" @click="toggleForm">Voltar ao login</b-button>
+      </div>
+    </b-card>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -110,3 +112,13 @@ function register() {
     .catch(() => showMessage('Register failed'))
 }
 </script>
+
+<style scoped>
+.popup-wrapper {
+  min-width: 300px;
+  max-width: 400px;
+  width: 100%;
+  max-height: 600px;
+  overflow-y: auto;
+}
+</style>


### PR DESCRIPTION
## Summary
- set viewport meta tag
- add width/height limits to popup layout

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684121cdb56c8324b6879484faf92409