### PR TITLE
Add context menu summary sidebar

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,14 +1,12 @@
-async function getApiBaseUrl(): Promise<string> {
-  const { API_BASE_URL } = await chrome.storage.local.get('API_BASE_URL');
-  if (API_BASE_URL) return API_BASE_URL as string;
-  const isDevelopment = !('update_url' in chrome.runtime.getManifest());
-  return isDevelopment ? 'http://localhost:3000' : 'https://your-production-url.com';
-}
+const isDevelopment = !('update_url' in chrome.runtime.getManifest());
+const API_BASE_URL = isDevelopment
+  ? 'http://localhost:3000'
+  : 'https://your-production-url.com';
+
 
 async function summarize(text: string): Promise<string> {
   try {
-    const baseUrl = await getApiBaseUrl();
-    const response = await fetch(`${baseUrl}/resumir`, {
+    const response = await fetch(`${API_BASE_URL}/resumir`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text })

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,6 +1,14 @@
+async function getApiBaseUrl(): Promise<string> {
+  const { API_BASE_URL } = await chrome.storage.local.get('API_BASE_URL');
+  if (API_BASE_URL) return API_BASE_URL as string;
+  const isDevelopment = !('update_url' in chrome.runtime.getManifest());
+  return isDevelopment ? 'http://localhost:3000' : 'https://your-production-url.com';
+}
+
 async function summarize(text: string): Promise<string> {
   try {
-    const response = await fetch('http://localhost:3000/resumir', {
+    const baseUrl = await getApiBaseUrl();
+    const response = await fetch(`${baseUrl}/resumir`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text })
@@ -25,13 +33,25 @@ chrome.runtime.onInstalled.addListener(() => {
   });
 });
 
+async function ensureContentScript(tabId: number): Promise<void> {
+  return new Promise((resolve) => {
+    chrome.tabs.sendMessage(tabId, { action: 'PING' }, (res) => {
+      if (chrome.runtime.lastError || !res) {
+        chrome.scripting.executeScript({
+          target: { tabId },
+          files: ['contentScript.js'],
+        }, () => resolve());
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
 chrome.contextMenus.onClicked.addListener(async (info, tab) => {
   if (info.menuItemId === 'resumir' && info.selectionText && tab?.id) {
     const resumo = await summarize(info.selectionText);
-    await chrome.scripting.executeScript({
-      target: { tabId: tab.id },
-      files: ['contentScript.js']
-    });
+    await ensureContentScript(tab.id);
     chrome.tabs.sendMessage(tab.id, { action: 'SHOW_SUMMARY', summary: resumo });
   }
 });

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,27 +1,16 @@
 async function summarize(text: string): Promise<string> {
   try {
-    const { API_TOKEN } = await chrome.storage.local.get(['API_TOKEN']);
-    if (!API_TOKEN) {
-      console.error('API token not found');
-      return 'Erro: API token não encontrado.';
-    }
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    const response = await fetch('http://localhost:3000/resumir', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${API_TOKEN}`,
-      },
-      body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
-        messages: [{ role: 'user', content: `Resuma o seguinte texto:\n\n${text}` }],
-      }),
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text })
     });
     if (!response.ok) {
       console.error(`Erro na API: ${response.status} ${response.statusText}`);
       return 'Erro ao conectar à API.';
     }
     const data = await response.json();
-    return data.choices?.[0]?.message?.content || 'Erro ao resumir.';
+    return data.resumo || data.summary || 'Erro ao resumir.';
   } catch (err) {
     console.error(err);
     return 'Erro ao conectar à API.';
@@ -37,8 +26,12 @@ chrome.runtime.onInstalled.addListener(() => {
 });
 
 chrome.contextMenus.onClicked.addListener(async (info, tab) => {
-  if (info.menuItemId === 'resumir' && info.selectionText) {
+  if (info.menuItemId === 'resumir' && info.selectionText && tab?.id) {
     const resumo = await summarize(info.selectionText);
-    chrome.storage.local.set({ LAST_SUMMARY: resumo });
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      files: ['contentScript.js']
+    });
+    chrome.tabs.sendMessage(tab.id, { action: 'SHOW_SUMMARY', summary: resumo });
   }
 });

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -27,7 +27,7 @@ function collectText(): string {
   return text;
 }
 
-function createSidebar() {
+function createSidebar(initialText = 'Gerando resumo...') {
   if ((window as any)[injectedFlag]) return null;
   (window as any)[injectedFlag] = true;
   const style = document.createElement('style');
@@ -37,7 +37,7 @@ function createSidebar() {
   const bar = document.createElement('div');
   bar.id = 'resumogpt-sidebar';
   const header = document.createElement('header');
-  header.textContent = 'Resumo da Página';
+  header.textContent = 'Resumo via GPT';
   const close = document.createElement('button');
   close.id = 'resumogpt-close';
   close.textContent = '\u00D7';
@@ -48,7 +48,7 @@ function createSidebar() {
   header.appendChild(close);
   const content = document.createElement('div');
   content.className = 'content';
-  content.textContent = 'Gerando resumo...';
+  content.textContent = initialText;
   bar.appendChild(header);
   bar.appendChild(content);
   document.body.appendChild(bar);
@@ -85,5 +85,15 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         });
     });
     sendResponse?.({status: 'started'});
+    return;
+  }
+
+  if (msg.action === 'SHOW_SUMMARY' && typeof msg.summary === 'string') {
+    const box = createSidebar(msg.summary);
+    if (!box) {
+      const existing = document.querySelector<HTMLDivElement>('#resumogpt-sidebar .content');
+      if (existing) existing.textContent = msg.summary;
+    }
+    sendResponse?.({status: 'shown'});
   }
 });

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -1,4 +1,5 @@
 const injectedFlag = '__resumogpt_sidebar_injected';
+const listenerFlag = '__resumogpt_listener_registered';
 
 function collectText(): string {
   const unwanted = ['script','style','noscript','header','nav','footer','code','pre','form'];
@@ -56,7 +57,14 @@ function createSidebar(initialText = 'Gerando resumo...') {
   return { bar, content };
 }
 
-chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+if (!(window as any)[listenerFlag]) {
+  (window as any)[listenerFlag] = true;
+
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    if (msg.action === 'PING') {
+      sendResponse?.({ status: 'pong' });
+      return;
+    }
   if (msg.action === 'SUMMARIZE_PAGE' && msg.baseUrl) {
     const box = createSidebar();
     if (!box) {
@@ -96,4 +104,5 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     }
     sendResponse?.({status: 'shown'});
   }
-});
+  });
+}


### PR DESCRIPTION
## Summary
- fetch summary from local API and inject sidebar
- display summary via SHOW_SUMMARY message in content script

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841b2bebe108324b7f6680e1da38288