### PR TITLE
Use user key for resumir

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -4,4 +4,3 @@ DB_USER=resumo
 DB_PASSWORD=secret
 DB_NAME=resumodb
 JWT_SECRET=change_this_secret
-OPENAI_API_KEY=your_openai_api_key

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,3 +4,4 @@ DB_USER=resumo
 DB_PASSWORD=secret
 DB_NAME=resumodb
 JWT_SECRET=change_this_secret
+OPENAI_API_KEY=your_openai_api_key

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "jsonwebtoken": "^9.0.0",
     "pg": "^8.11.1",
     "sequelize": "^6.37.1",
-    "pg-hstore": "^2.3.4"
+    "pg-hstore": "^2.3.4",
+    "openai": "^5.1.1"
   }
 }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -3,6 +3,7 @@ const express = require('express')
 const bcrypt = require('bcrypt')
 const jwt = require('jsonwebtoken')
 const cors = require('cors')
+const OpenAI = require('openai')
 
 
 const { initDb } = require('./db')
@@ -106,6 +107,34 @@ async function start() {
     } catch (err) {
       console.error(err);
       res.status(500).json({ error: 'failed to update API Key' });
+    }
+  });
+
+  // Endpoint autenticado que usa a chave do usuário armazenada no banco
+  app.post('/resumir', authMiddleware, async (req, res) => {
+    const { texto } = req.body;
+    if (!texto) {
+      return res.status(400).json({ error: 'texto obrigatório' });
+    }
+    try {
+      const user = await User.findByPk(req.userId);
+      if (!user || !user.api_key) {
+        return res.status(400).json({ error: 'API key não configurada' });
+      }
+
+      const client = new OpenAI({ apiKey: user.api_key });
+      const completion = await client.chat.completions.create({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          { role: 'system', content: 'Resuma o texto a seguir em até 5 frases.' },
+          { role: 'user', content: texto }
+        ]
+      });
+      const resumo = completion.choices?.[0]?.message?.content?.trim() || '';
+      res.json({ resumo });
+    } catch (err) {
+      console.error('resumir failed', err);
+      res.status(500).json({ error: 'falha ao resumir' });
     }
   });
 

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -110,10 +110,9 @@ async function start() {
     }
   });
 
-  // Endpoint autenticado que usa a chave do usuário armazenada no banco
   app.post('/resumir', authMiddleware, async (req, res) => {
-    const { texto } = req.body;
-    if (!texto) {
+    const { text } = req.body;
+    if (!text) {
       return res.status(400).json({ error: 'texto obrigatório' });
     }
     try {
@@ -121,13 +120,12 @@ async function start() {
       if (!user || !user.api_key) {
         return res.status(400).json({ error: 'API key não configurada' });
       }
-
       const client = new OpenAI({ apiKey: user.api_key });
       const completion = await client.chat.completions.create({
         model: 'gpt-3.5-turbo',
         messages: [
           { role: 'system', content: 'Resuma o texto a seguir em até 5 frases.' },
-          { role: 'user', content: texto }
+          { role: 'user', content: text }
         ]
       });
       const resumo = completion.choices?.[0]?.message?.content?.trim() || '';

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -6,17 +6,28 @@ const API_BASE_URL = isDevelopment
 
 async function summarize(text: string): Promise<string> {
   try {
+    const token: string = await new Promise((resolve) => {
+      chrome.storage.local.get('JWT_TOKEN', (result) => {
+        resolve(result.JWT_TOKEN);
+      });
+    });
+
     const response = await fetch(`${API_BASE_URL}/resumir`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
       body: JSON.stringify({ text })
     });
+
     if (!response.ok) {
       console.error(`Erro na API: ${response.status} ${response.statusText}`);
       return 'Erro ao conectar à API.';
     }
-    const data = await response.json();
-    return data.resumo || data.summary || 'Erro ao resumir.';
+
+    const json = await response.json();
+    return json.resumo || json.summary || 'Erro ao resumir.';
   } catch (err) {
     console.error(err);
     return 'Erro ao conectar à API.';


### PR DESCRIPTION
## Summary
- update `/resumir` to require auth and use the logged-in user's API key
- remove unused global OpenAI client

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842effd3c6c83249d941bae4c679879