### PR TITLE
Add Docker debugging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,30 @@ The API exposes the following endpoints:
 
 Sequelize manages the PostgreSQL schema and creates the required tables when the server starts.
 The server waits for this initialization to finish before it begins accepting requests.
+
+## Debugging the API inside Docker
+
+To attach a debugger to the Node.js process in the `api` container, expose the
+inspection port and run the server with the `debug` script.
+
+1. Update `docker-compose.yml` to map port `9229` and run the debug command.
+   The `api` service should look like:
+
+   ```yaml
+   api:
+     build: ./server
+     restart: always
+     command: npm run debug
+     ports:
+       - "3000:3000"
+       - "9229:9229"
+   ```
+
+2. Start the containers:
+
+   ```bash
+   docker-compose up --build
+   ```
+
+3. Attach your debugger (e.g. Chrome DevTools or VS Code) to
+   `localhost:9229` and set breakpoints normally.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
   api:
     build: ./server
     restart: always
+    command: npm run debug
     environment:
       DB_HOST: ${DB_HOST}
       DB_PORT: ${DB_PORT}
@@ -25,5 +26,6 @@ services:
       - postgres
     ports:
       - "3000:3000"
+      - "9229:9229"
 volumes:
   postgres-data:

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
     "node": "18.x"
   },
   "scripts": {
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "debug": "node --inspect=0.0.0.0:9229 src/index.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.0",


### PR DESCRIPTION
## Summary
- document how to debug the API container
- add debug script to backend package.json
- expose Node's inspect port in docker-compose

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68439ab308c8832496a9a34c8963f5a4