### PR TITLE
Fix API container entrypoint

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:18-alpine
 WORKDIR /app
-COPY package.json ./
-RUN npm install --production
+COPY package.json package-lock.json tsconfig.json ./
+RUN npm install
 COPY . ./
+RUN npm run build && npm prune --production
 CMD ["npm", "start"]

--- a/server/package.json
+++ b/server/package.json
@@ -7,8 +7,9 @@
     "node": "18.x"
   },
   "scripts": {
-    "start": "node src/index.js",
-    "debug": "node --inspect=0.0.0.0:9229 src/index.js"
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "debug": "node --inspect=0.0.0.0:9229 dist/server.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.0",


### PR DESCRIPTION
## Summary
- fix API start script to use compiled JS
- build TypeScript during Docker image creation

## Testing
- `npm run build` (in server/)

------
https://chatgpt.com/codex/tasks/task_e_6843a64924fc8324849f4b1246220580