### PR TITLE
Fix backend Docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ docker-compose up --build
 
 Environment variables can be configured by copying `server/.env.example` to `server/.env` and adjusting the values.
 
+When running the backend locally without Docker you must compile the TypeScript source first:
+
+```bash
+cd server
+npm install
+npm run build
+npm start
+```
+
+The Docker image performs these steps automatically during `docker-compose up`.
+
 The API exposes the following endpoints:
 
 - `POST /register` – create a new user with hashed password.

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,10 @@
 FROM node:18-alpine
 WORKDIR /app
-COPY package.json ./
-RUN npm install --production
+COPY package.json package-lock.json tsconfig.json ./
+RUN apk add --no-cache --virtual .build-deps \
+    make g++ python3 && \
+    npm install && \
+    apk del .build-deps
 COPY . ./
+RUN npm run build && npm prune --production
 CMD ["npm", "start"]

--- a/server/package.json
+++ b/server/package.json
@@ -7,8 +7,9 @@
     "node": "18.x"
   },
   "scripts": {
-    "start": "node src/index.js",
-    "debug": "node --inspect=0.0.0.0:9229 src/index.js"
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "debug": "node --inspect=0.0.0.0:9229 dist/server.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.0",


### PR DESCRIPTION
## Summary
- compile backend TypeScript before running
- install build tools so bcrypt can compile on Alpine
- document the TypeScript build step in README

## Testing
- `npm run build`
- `cd server && npm run build`
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843a64924fc8324849f4b1246220580