### PR TITLE
Fix ready.html layout in extension

### DIFF
--- a/public/ready.html
+++ b/public/ready.html
@@ -6,7 +6,22 @@
   <title>ResumoGPT</title>
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
   <style>
-    body { font-family: 'Open Sans', sans-serif; text-align: center; padding: 20px; }
+    html, body {
+      width: 360px;
+      height: 500px;
+      margin: 0;
+    }
+
+    body {
+      font-family: 'Open Sans', sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      overflow: hidden;
+      text-align: center;
+      padding: 20px;
+      box-sizing: border-box;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- style `ready.html` so the popup has set dimensions

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843ca4e33908324b55c8299fcb5899a