### PR TITLE
Add support for DeepSeek API

### DIFF
--- a/server/schema.sql
+++ b/server/schema.sql
@@ -3,5 +3,6 @@ CREATE TABLE IF NOT EXISTS users (
   username VARCHAR(100) UNIQUE NOT NULL,
   email VARCHAR(100) UNIQUE NOT NULL,
   password_hash TEXT NOT NULL,
-  api_key TEXT
+  api_key TEXT,
+  api_key_type VARCHAR(20)
 );

--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -6,11 +6,11 @@ export class AuthController {
 
   async register(req: Request, res: Response, next: NextFunction) {
     try {
-      const { username, email, password, apiKey } = req.body
+      const { username, email, password, apiKey, tipo } = req.body
       if (!username || !email || !password) {
         return res.status(400).json({ error: 'username, email and password required' })
       }
-      await this.service.register(username, email, password, apiKey)
+      await this.service.register(username, email, password, apiKey, tipo)
       res.status(201).json({ message: 'user created' })
     } catch (err) {
       next(err)
@@ -36,7 +36,12 @@ export class AuthController {
       if (!user) {
         return res.status(404).json({ error: 'user not found' })
       }
-      res.json(user)
+      res.json({
+        username: (user as any).username,
+        email: (user as any).email,
+        api_key: (user as any).api_key,
+        tipoApiKey: (user as any).api_key_type
+      })
     } catch (err) {
       next(err)
     }
@@ -44,11 +49,14 @@ export class AuthController {
 
   async updateApiKey(req: Request, res: Response, next: NextFunction) {
     try {
-      const { apiKey } = req.body
-      if (!apiKey) {
-        return res.status(400).json({ error: 'apiKey required' })
+      const { apiKey, tipo } = req.body
+      if (!apiKey || !tipo) {
+        return res.status(400).json({ error: 'apiKey and tipo required' })
       }
-      await this.service.updateApiKey((req as any).userId, apiKey)
+      if (tipo !== 'openai' && tipo !== 'deepseek') {
+        return res.status(400).json({ error: 'invalid tipo' })
+      }
+      await this.service.updateApiKey((req as any).userId, apiKey, tipo)
       res.json({ message: 'API Key updated' })
     } catch (err) {
       next(err)

--- a/server/src/controllers/resumo.controller.ts
+++ b/server/src/controllers/resumo.controller.ts
@@ -14,7 +14,9 @@ export class ResumoController {
       if (!user || !(user as any).api_key) {
         return res.status(400).json({ error: 'API key not configured' })
       }
-      const service = new ResumoService(createOpenAIClient((user as any).api_key))
+      const service = new ResumoService(
+        createOpenAIClient((user as any).api_key, (user as any).api_key_type || 'openai')
+      )
       const resumo = await service.gerarResumo(text)
       res.json({ resumo })
     } catch (err) {

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -24,6 +24,9 @@ const User = sequelize.define('User', {
   api_key: {
     type: DataTypes.TEXT,
   },
+  api_key_type: {
+    type: DataTypes.STRING(20),
+  },
 }, {
   tableName: 'users',
   timestamps: false,

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -4,9 +4,21 @@ import User from '../models/user'
 import { env } from '../config/env'
 
 export class AuthService {
-  async register(username: string, email: string, password: string, apiKey?: string): Promise<void> {
+  async register(
+    username: string,
+    email: string,
+    password: string,
+    apiKey?: string,
+    tipo: 'openai' | 'deepseek' = 'openai'
+  ): Promise<void> {
     const hash = await bcrypt.hash(password, 10)
-    await User.create({ username, email, password_hash: hash, api_key: apiKey || null })
+    await User.create({
+      username,
+      email,
+      password_hash: hash,
+      api_key: apiKey || null,
+      api_key_type: tipo
+    })
   }
 
   async login(email: string, password: string): Promise<string> {
@@ -22,16 +34,21 @@ export class AuthService {
   }
   async getCurrentUser(userId: number) {
     return User.findByPk(userId, {
-      attributes: ['username', 'email', 'api_key'],
+      attributes: ['username', 'email', 'api_key', 'api_key_type'],
     })
   }
 
-  async updateApiKey(userId: number, apiKey: string): Promise<void> {
+  async updateApiKey(
+    userId: number,
+    apiKey: string,
+    tipo: 'openai' | 'deepseek'
+  ): Promise<void> {
     const user = await User.findByPk(userId)
     if (!user) {
       throw new Error('user not found')
     }
     ;(user as any).api_key = apiKey
+    ;(user as any).api_key_type = tipo
     await user.save()
   }
 }

--- a/server/src/utils/openaiClient.ts
+++ b/server/src/utils/openaiClient.ts
@@ -1,5 +1,8 @@
 import OpenAI from 'openai'
 
-export const createOpenAIClient = (apiKey: string) => {
-  return new OpenAI({ apiKey })
+export const createOpenAIClient = (apiKey: string, tipo: 'openai' | 'deepseek' = 'openai') => {
+  return new OpenAI({
+    apiKey,
+    baseURL: tipo === 'deepseek' ? 'https://api.deepseek.com' : 'https://api.openai.com'
+  })
 }

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -32,7 +32,8 @@ function collectText(): string {
   });
   let text = '';
   while (walker.nextNode()) {
-    text += walker.currentNode.nodeValue.trim() + ' ';
+    const val = walker.currentNode.nodeValue || '';
+    text += val.trim() + ' ';
     if (text.length > 6000) break;
   }
   return text;

--- a/src/dashboard/main.ts
+++ b/src/dashboard/main.ts
@@ -3,11 +3,12 @@ import App from './App.vue';
 import '../assets/styles/main.scss';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap-vue-next/dist/bootstrap-vue-next.css';
-import { createBootstrap, BCard, BButton, BFormInput } from 'bootstrap-vue-next';
+import { createBootstrap, BCard, BButton, BFormInput, BFormSelect } from 'bootstrap-vue-next';
 
 const app = createApp(App);
 app.use(createBootstrap());
 app.component('BCard', BCard);
 app.component('BButton', BButton);
 app.component('BFormInput', BFormInput);
+app.component('BFormSelect', BFormSelect);
 app.mount('#app');

--- a/tests/contentScript.spec.ts
+++ b/tests/contentScript.spec.ts
@@ -1,7 +1,7 @@
 let createSidebar: any;
 
 beforeAll(async () => {
-  (global as any).chrome = {
+  (globalThis as any).chrome = {
     runtime: {
       getURL: jest.fn(() => ''),
       onMessage: { addListener: jest.fn() }

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -1,7 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import Dashboard from '../src/dashboard/App.vue';
 import fetchMock from 'jest-fetch-mock';
-import { BCard, BButton, BFormInput } from 'bootstrap-vue-next';
+import { BCard, BButton, BFormInput, BFormSelect } from 'bootstrap-vue-next';
 import { createMemoryHistory, createRouter } from 'vue-router';
 
 describe('Dashboard storage', () => {
@@ -11,7 +11,7 @@ describe('Dashboard storage', () => {
     const router = createRouter({ history: createMemoryHistory(), routes: [] });
     wrapper = shallowMount(Dashboard, {
       global: {
-        components: { BCard, BButton, BFormInput },
+        components: { BCard, BButton, BFormInput, BFormSelect },
         plugins: [router]
       }
     });
@@ -21,9 +21,12 @@ describe('Dashboard storage', () => {
     (chrome.storage.local.get as jest.Mock).mockImplementationOnce((_k, cb) => cb({ JWT_TOKEN: 'tok' }));
     fetchMock.mockResponseOnce(JSON.stringify({ message: 'ok' }));
     wrapper.vm.apiKey = 'XYZ';
+    wrapper.vm.tipo = 'deepseek';
     await wrapper.vm.saveApiKey();
     await new Promise(process.nextTick);
-    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/me/api-key'), expect.any(Object));
+    const call = (fetchMock as any).mock.calls[0];
+    expect(call[0]).toContain('/me/api-key');
+    expect(JSON.parse(call[1].body).tipo).toBe('deepseek');
     expect((chrome.storage.local.set as jest.Mock).mock.calls[0][0]).toEqual({ API_TOKEN: 'XYZ' });
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "types": ["bootstrap-vue-next", "jest", "chrome"],
-    "lib": ["dom", "esnext"]
+    "lib": ["dom", "esnext"],
+    "skipLibCheck": true
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- allow choosing DeepSeek or OpenAI for API requests
- store API key type on the server
- set baseURL in OpenAI client based on api type
- expose the api key type on `/me`
- adjust dashboard UI for selecting provider
- update tests and TypeScript settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684740b353b083248a5ea13eef641938