### PR TITLE
Refactor backend to use tsyringe DI

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,7 +17,9 @@
         "openai": "^5.1.1",
         "pg": "^8.11.1",
         "pg-hstore": "^2.3.4",
-        "sequelize": "^6.37.1"
+        "reflect-metadata": "^0.1.13",
+        "sequelize": "^6.37.1",
+        "tsyringe": "^4.8.0"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
@@ -1602,6 +1604,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
+      "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
+      "license": "Apache-2.0"
+    },
     "node_modules/retry-as-promised": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.1.1.tgz",
@@ -1991,6 +1999,24 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/type-is": {

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,9 @@
     "openai": "^5.1.1",
     "pg": "^8.11.1",
     "pg-hstore": "^2.3.4",
-    "sequelize": "^6.37.1"
+    "sequelize": "^6.37.1",
+    "tsyringe": "^4.8.0",
+    "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -1,6 +1,8 @@
 import { Request, Response, NextFunction } from 'express'
+import { container, injectable } from 'tsyringe'
 import { AuthService } from '../services/auth.service'
 
+@injectable()
 export class AuthController {
   constructor(private service: AuthService) {}
 
@@ -64,4 +66,4 @@ export class AuthController {
   }
 }
 
-export const authController = new AuthController(new AuthService())
+export const authController = container.resolve(AuthController)

--- a/server/src/di.ts
+++ b/server/src/di.ts
@@ -1,0 +1,15 @@
+import 'reflect-metadata'
+import { container } from 'tsyringe'
+import { AuthService } from './services/auth.service'
+import { ResumoService } from './services/resumo.service'
+import { createOpenAIClient, OpenAIClientFactory } from './utils/openaiClient'
+
+export function setupDi(): void {
+  container.registerSingleton(AuthService)
+  container.registerSingleton(ResumoService)
+  container.register<OpenAIClientFactory>('OpenAIClientFactory', {
+    useValue: createOpenAIClient,
+  })
+}
+
+export { container }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,8 +1,11 @@
+import "reflect-metadata"
 import { createApp } from './app'
 import { env } from './config/env'
 import { initDb } from './db'
+import { setupDi } from './di'
 
 async function start() {
+  setupDi()
   await initDb()
   const app = createApp()
   const PORT = parseInt(env.port, 10)

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -1,8 +1,10 @@
 import bcrypt from 'bcrypt'
 import jwt from 'jsonwebtoken'
+import { injectable } from 'tsyringe'
 import User from '../models/user'
 import { env } from '../config/env'
 
+@injectable()
 export class AuthService {
   async register(
     username: string,

--- a/server/src/services/resumo.service.ts
+++ b/server/src/services/resumo.service.ts
@@ -1,10 +1,20 @@
 import OpenAI from 'openai'
+import { inject, injectable } from 'tsyringe'
+import { OpenAIClientFactory } from '../utils/openaiClient'
 
+@injectable()
 export class ResumoService {
-  constructor(private client: OpenAI) {}
+  constructor(
+    @inject('OpenAIClientFactory') private readonly createClient: OpenAIClientFactory
+  ) {}
 
-  async gerarResumo(texto: string): Promise<string> {
-    const completion = await this.client.chat.completions.create({
+  async gerarResumo(
+    texto: string,
+    apiKey: string,
+    tipo: 'openai' | 'deepseek' = 'openai'
+  ): Promise<string> {
+    const client = this.createClient(apiKey, tipo)
+    const completion = await client.chat.completions.create({
       model: 'gpt-4o-mini',
       messages: [
         { role: 'system', content: 'Resuma o texto a seguir em até 5 frases.' },

--- a/server/src/utils/openaiClient.ts
+++ b/server/src/utils/openaiClient.ts
@@ -1,8 +1,19 @@
 import OpenAI from 'openai'
 
-export const createOpenAIClient = (apiKey: string, tipo: 'openai' | 'deepseek' = 'openai') => {
+export type OpenAIClientFactory = (
+  apiKey: string,
+  tipo: 'openai' | 'deepseek'
+) => OpenAI
+
+export const createOpenAIClient: OpenAIClientFactory = (
+  apiKey,
+  tipo = 'openai'
+) => {
   return new OpenAI({
     apiKey,
-    baseURL: tipo === 'deepseek' ? 'https://api.deepseek.com' : 'https://api.openai.com'
+    baseURL:
+      tipo === 'deepseek'
+        ? 'https://api.deepseek.com'
+        : 'https://api.openai.com'
   })
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -6,7 +6,11 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
-    "sourceMap": true 
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- install `tsyringe` and `reflect-metadata`
- enable decorators in TypeScript config
- create `di.ts` for dependency registrations
- refactor services and controllers to use dependency injection
- inject OpenAI client via token
- bootstrap container in server entrypoint

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68476c9730508324a1d7b982f4f27d12