### PR TITLE
Add Ready page with dashboard link

### DIFF
--- a/frontend/public/ready.html
+++ b/frontend/public/ready.html
@@ -25,6 +25,8 @@
   </style>
 </head>
 <body>
-  <h1>Pronto! Agora é só resumir as coisas 😎</h1>
+  <div id="app"></div>
+  <script type="module" src="./config.js"></script>
+  <script type="module" src="/src/ready/main.ts"></script>
 </body>
 </html>

--- a/frontend/src/ready/App.vue
+++ b/frontend/src/ready/App.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="ready-wrapper container mx-auto d-flex align-items-center justify-content-center">
+    <b-card class="text-center">
+      <h2>Pronto! Agora é só resumir as coisas 😎</h2>
+      <b-button variant="outline-primary" class="mt-3" @click="irParaDashboard">
+        Alterar API Key
+      </b-button>
+    </b-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+const router = useRouter()
+function irParaDashboard() {
+  router.push('/dashboard')
+}
+</script>
+
+<style scoped>
+.ready-wrapper {
+  max-width: 400px;
+  margin: auto;
+  animation: fadeIn 0.5s ease;
+}
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+</style>

--- a/frontend/src/ready/main.ts
+++ b/frontend/src/ready/main.ts
@@ -1,0 +1,14 @@
+import { createApp } from 'vue'
+import '../assets/styles/main.scss'
+import 'bootstrap/dist/css/bootstrap.css'
+import 'bootstrap-vue-next/dist/bootstrap-vue-next.css'
+import { createBootstrap, BCard, BButton } from 'bootstrap-vue-next'
+import App from './App.vue'
+import { router } from '../router'
+
+const app = createApp(App)
+app.use(createBootstrap())
+app.use(router)
+app.component('BCard', BCard)
+app.component('BButton', BButton)
+app.mount('#app')

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -1,12 +1,16 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import Popup from './popup/App.vue'
 import Dashboard from './dashboard/App.vue'
+import Ready from './ready/App.vue'
 
 export const router = createRouter({
   history: createWebHistory(),
   routes: [
     { path: '/popup.html', component: Popup },
     { path: '/dashboard.html', component: Dashboard },
+    { path: '/dashboard', component: Dashboard },
+    { path: '/ready.html', component: Ready },
+    { path: '/ready', component: Ready },
     { path: '/', redirect: '/popup.html' }
   ]
 })


### PR DESCRIPTION
## Summary
- create `ready` view with fade-in animation and button to go to dashboard
- mount `ready` view using main.ts and update ready.html template
- register `/ready` routes alongside existing ones

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684784ec2e5c83249393779f16700c5d