### PR TITLE
Fix dashboard redirect from ready page

### DIFF
--- a/frontend/src/ready/App.vue
+++ b/frontend/src/ready/App.vue
@@ -10,10 +10,8 @@
 </template>
 
 <script setup lang="ts">
-import { useRouter } from 'vue-router'
-const router = useRouter()
 function irParaDashboard() {
-  router.push('/dashboard')
+  window.location.href = 'dashboard.html'
 }
 </script>
 

--- a/frontend/src/ready/main.ts
+++ b/frontend/src/ready/main.ts
@@ -4,11 +4,9 @@ import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap-vue-next/dist/bootstrap-vue-next.css'
 import { createBootstrap, BCard, BButton } from 'bootstrap-vue-next'
 import App from './App.vue'
-import { router } from '../router'
 
 const app = createApp(App)
 app.use(createBootstrap())
-app.use(router)
 app.component('BCard', BCard)
 app.component('BButton', BButton)
 app.mount('#app')


### PR DESCRIPTION
## Summary
- remove Vue Router from the `ready` page and use `window.location.href`

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684786dba07c8324bbd386fc8c39767b