### PR TITLE
Implement history and API fallback

### DIFF
--- a/frontend/src/background/index.ts
+++ b/frontend/src/background/index.ts
@@ -1,3 +1,5 @@
+import { addToHistory } from '../history/store';
+
 const isDevelopment = !('update_url' in chrome.runtime.getManifest());
 const API_BASE_URL = isDevelopment
   ? 'http://localhost:3000/api'
@@ -34,14 +36,6 @@ async function summarize(text: string): Promise<{ resumo: string; tipoUsado: str
   }
 }
 
-function addToHistory(original: string, resumo: string, url: string) {
-  chrome.storage.local.get('SUMMARY_HISTORY', data => {
-    const history = Array.isArray(data.SUMMARY_HISTORY) ? data.SUMMARY_HISTORY : []
-    history.unshift({ original, resumo, url, timestamp: Date.now() })
-    if (history.length > 5) history.splice(5)
-    chrome.storage.local.set({ SUMMARY_HISTORY: history })
-  })
-}
 
 chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.create({

--- a/frontend/src/contentScript.ts
+++ b/frontend/src/contentScript.ts
@@ -1,3 +1,5 @@
+import { addToHistory } from './history/store';
+
 const injectedFlag = '__resumogpt_sidebar_injected';
 const listenerFlag = '__resumogpt_listener_registered';
 const cssFlag = '__resumogpt_css_inserted';
@@ -111,12 +113,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           const summary = data.summary || data.error || 'Falha ao resumir.';
           box.content.textContent = summary;
           chrome.storage.local.set({ PAGE_SUMMARY: summary });
-          chrome.storage.local.get('SUMMARY_HISTORY', d => {
-            const history = Array.isArray(d.SUMMARY_HISTORY) ? d.SUMMARY_HISTORY : []
-            history.unshift({ original: text, resumo: summary, url: window.location.href, timestamp: Date.now() })
-            if (history.length > MAX_HISTORY_ITEMS) history.splice(MAX_HISTORY_ITEMS)
-            chrome.storage.local.set({ SUMMARY_HISTORY: history })
-          })
+          addToHistory(text, summary, window.location.href)
         })
         .catch(() => {
           box.content.textContent = 'Erro ao conectar à API.';

--- a/frontend/src/contentScript.ts
+++ b/frontend/src/contentScript.ts
@@ -114,7 +114,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           chrome.storage.local.get('SUMMARY_HISTORY', d => {
             const history = Array.isArray(d.SUMMARY_HISTORY) ? d.SUMMARY_HISTORY : []
             history.unshift({ original: text, resumo: summary, url: window.location.href, timestamp: Date.now() })
-            if (history.length > 5) history.splice(5)
+            if (history.length > MAX_HISTORY_ITEMS) history.splice(MAX_HISTORY_ITEMS)
             chrome.storage.local.set({ SUMMARY_HISTORY: history })
           })
         })

--- a/frontend/src/dashboard/App.vue
+++ b/frontend/src/dashboard/App.vue
@@ -12,6 +12,7 @@
       <small v-if="apiKeyType === 'deepseek'" class="text-muted text-sm mt-1">DeepSeek usa a mesma API do OpenAI porém com outra base URL.</small>
       <div class="d-flex justify-content-between mb-3">
         <b-button id="save-api-key" variant="primary" @click="saveApiKey">Salvar API Key</b-button>
+        <b-button variant="secondary" @click="router.push('/history')">Histórico</b-button>
         <b-button id="logout" variant="danger" @click="logout">Logout</b-button>
       </div>
       <div id="api-message" class="success" v-if="apiMessage">{{ apiMessage }}</div>

--- a/frontend/src/history/App.vue
+++ b/frontend/src/history/App.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="history-wrapper container mx-auto">
+    <b-card>
+      <h2>Histórico de Resumos</h2>
+      <div v-if="items.length === 0">Nenhum resumo salvo</div>
+      <div v-for="it in items" :key="it.timestamp" class="mb-3">
+        <div class="small text-muted">
+          {{ new Date(it.timestamp).toLocaleString() }} -
+          <a :href="it.url" target="_blank">{{ it.url }}</a>
+        </div>
+        <div class="fw-bold">{{ it.original }}</div>
+        <div>{{ it.resumo }}</div>
+        <hr />
+      </div>
+      <b-button variant="primary" @click="voltar">Voltar</b-button>
+    </b-card>
+  </div>
+</template>
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+interface Item {
+  original: string
+  resumo: string
+  url: string
+  timestamp: number
+}
+const items = ref<Item[]>([])
+const router = useRouter()
+
+onMounted(() => {
+  chrome.storage.local.get('SUMMARY_HISTORY', data => {
+    items.value = data.SUMMARY_HISTORY || []
+  })
+})
+function voltar() {
+  router.back()
+}
+</script>
+<style scoped>
+.history-wrapper {
+  max-width: 400px;
+  margin: auto;
+  max-height: 600px;
+  overflow-y: auto;
+}
+</style>

--- a/frontend/src/history/App.vue
+++ b/frontend/src/history/App.vue
@@ -19,19 +19,12 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-interface Item {
-  original: string
-  resumo: string
-  url: string
-  timestamp: number
-}
-const items = ref<Item[]>([])
+import { loadHistory, SummaryItem } from './store'
+const items = ref<SummaryItem[]>([])
 const router = useRouter()
 
 onMounted(() => {
-  chrome.storage.local.get('SUMMARY_HISTORY', data => {
-    items.value = data.SUMMARY_HISTORY || []
-  })
+  loadHistory(h => (items.value = h))
 })
 function voltar() {
   router.back()

--- a/frontend/src/history/store.ts
+++ b/frontend/src/history/store.ts
@@ -1,0 +1,23 @@
+export interface SummaryItem {
+  original: string
+  resumo: string
+  url: string
+  timestamp: number
+}
+
+export function addToHistory(original: string, resumo: string, url: string) {
+  chrome.storage.local.get('SUMMARY_HISTORY', data => {
+    const history = Array.isArray(data.SUMMARY_HISTORY)
+      ? (data.SUMMARY_HISTORY as SummaryItem[])
+      : []
+    history.unshift({ original, resumo, url, timestamp: Date.now() })
+    if (history.length > 5) history.splice(5)
+    chrome.storage.local.set({ SUMMARY_HISTORY: history })
+  })
+}
+
+export function loadHistory(cb: (items: SummaryItem[]) => void) {
+  chrome.storage.local.get('SUMMARY_HISTORY', data => {
+    cb(Array.isArray(data.SUMMARY_HISTORY) ? data.SUMMARY_HISTORY : [])
+  })
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -3,6 +3,7 @@ import Login from '../pages/Login.vue'
 import Register from '../pages/Register.vue'
 import Dashboard from '../dashboard/App.vue'
 import Ready from '../ready/App.vue'
+import History from '../history/App.vue'
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -11,6 +12,7 @@ const router = createRouter({
     { path: '/register', component: Register },
     { path: '/dashboard', component: Dashboard },
     { path: '/ready', component: Ready },
+    { path: '/history', component: History },
     { path: '/', redirect: '/login' }
   ]
 })

--- a/frontend/tests/background.spec.ts
+++ b/frontend/tests/background.spec.ts
@@ -1,6 +1,7 @@
 import fetchMock from 'jest-fetch-mock';
 
 let summarize: any;
+let addToHistory: any;
 
 beforeAll(async () => {
   (global as any).chrome = {
@@ -14,18 +15,32 @@ beforeAll(async () => {
     tabs: { sendMessage: jest.fn() },
     scripting: { insertCSS: jest.fn(), executeScript: jest.fn() }
   } as any;
-  summarize = (await import('../src/background/index')).summarize;
+  const mod = await import('../src/background/index');
+  summarize = mod.summarize;
+  addToHistory = mod.addToHistory;
 });
 
 describe('Background summarize', () => {
   it('posts text with JWT token and returns summary', async () => {
     (chrome.storage.local.get as jest.Mock).mockImplementationOnce((_k, cb) => cb({ JWT_TOKEN: 'tok' }));
-    fetchMock.mockResponseOnce(JSON.stringify({ resumo: 'short' }), { status: 200 });
+    fetchMock.mockResponseOnce(JSON.stringify({ resumo: 'short', tipoUsado: 'openai' }), { status: 200 });
     const result = await summarize('hello');
     expect(fetchMock).toHaveBeenCalledWith('http://localhost:3000/api/resumir', expect.objectContaining({
       method: 'POST',
       headers: expect.objectContaining({ Authorization: 'Bearer tok' })
     }));
-    expect(result).toBe('short');
+    expect(result.resumo).toBe('short');
+    expect(result.tipoUsado).toBe('openai');
   });
 });
+
+describe('History', () => {
+  it('keeps only last 5 items', () => {
+    const setMock = chrome.storage.local.set as jest.Mock
+    const getMock = chrome.storage.local.get as jest.Mock
+    getMock.mockImplementation((_k, cb) => cb({ SUMMARY_HISTORY: [1,2,3,4,5] }))
+    addToHistory('o','r','u')
+    const arr = setMock.mock.calls[0][0].SUMMARY_HISTORY
+    expect(arr.length).toBe(5)
+  })
+})

--- a/server/src/controllers/resumo.controller.ts
+++ b/server/src/controllers/resumo.controller.ts
@@ -18,12 +18,12 @@ export class ResumoController {
       if (!user || !(user as any).api_key) {
         return res.status(400).json({ error: 'API key not configured' })
       }
-      const resumo = await this.service.gerarResumo(
+      const { resumo, tipoUsado } = await this.service.gerarResumo(
         text,
         (user as any).api_key,
         (user as any).api_key_type || ApiKeyType.OPENAI
       )
-      res.json({ resumo })
+      res.json({ resumo, tipoUsado })
     } catch (err) {
       next(err)
     }

--- a/server/tests/resumo.service.spec.ts
+++ b/server/tests/resumo.service.spec.ts
@@ -1,0 +1,22 @@
+import 'reflect-metadata'
+import { ResumoService } from '../src/services/resumo.service'
+import { ApiKeyType } from '../src/types/apiKeyType'
+
+describe('ResumoService fallback', () => {
+  it('tries next API when first fails', async () => {
+    const client1 = {
+      chat: { completions: { create: jest.fn().mockRejectedValue(new Error('x')) } }
+    } as any
+    const client2 = {
+      chat: { completions: { create: jest.fn().mockResolvedValue({ choices: [{ message: { content: 'ok' } }] }) } }
+    } as any
+    const factory = jest
+      .fn()
+      .mockReturnValueOnce(client1)
+      .mockReturnValueOnce(client2)
+    const service = new ResumoService(factory)
+    const result = await service.gerarResumo('t', 'key', ApiKeyType.OPENAI)
+    expect(result.resumo).toBe('ok')
+    expect(result.tipoUsado).toBe(ApiKeyType.DEEPSEEK)
+  })
+})


### PR DESCRIPTION
## Summary
- add AI fallback order inside ResumoService
- return which API type was used
- persist summaries in a new SUMMARY_HISTORY list
- show history page and routing
- record API type in sidebar
- cover fallback and history logic with tests

## Testing
- `npm test` in `server`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68498db31d5c832494bce1988c5b80f0