### PR TITLE
Apply unified popup layout styles

### DIFF
--- a/frontend/src/assets/styles/main.scss
+++ b/frontend/src/assets/styles/main.scss
@@ -2,5 +2,25 @@
 @use 'bootstrap/scss/bootstrap' as bootstrap;
 
 body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
   font-family: 'Open Sans', Arial, sans-serif;
+}
+
+.popup-wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  max-width: 360px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+.auth-card,
+.dashboard-card {
+  width: 100%;
 }

--- a/frontend/src/dashboard/App.vue
+++ b/frontend/src/dashboard/App.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="popup-wrapper container mx-auto text-center p-3">
-    <b-card>
+  <div class="popup-wrapper text-center p-3">
+    <b-card class="dashboard-card">
       <h1>Dashboard</h1>
       <div id="info">{{ info }}</div>
       <b-form-input v-model="apiKey" id="api-key" type="text" placeholder="API Key" class="mb-3" />
@@ -91,12 +91,3 @@ function saveApiKey() {
   });
 }
 </script>
-<style scoped>
-.popup-wrapper {
-  min-width: 300px;
-  max-width: 400px;
-  width: 100%;
-  max-height: 600px;
-  overflow-y: auto;
-}
-</style>

--- a/frontend/src/history/App.vue
+++ b/frontend/src/history/App.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="history-wrapper container mx-auto">
-    <b-card>
+  <div class="popup-wrapper history-wrapper">
+    <b-card class="dashboard-card">
       <h2>Histórico de Resumos</h2>
       <div v-if="items.length === 0">Nenhum resumo salvo</div>
       <div v-for="it in items" :key="it.timestamp" class="mb-3">
@@ -32,8 +32,6 @@ function voltar() {
 </script>
 <style scoped>
 .history-wrapper {
-  max-width: 400px;
-  margin: auto;
   max-height: 600px;
   overflow-y: auto;
 }

--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup-wrapper d-flex align-items-center justify-content-center">
+  <div class="popup-wrapper">
     <b-card class="auth-card shadow-sm">
       <h2 class="text-center mb-4">Login</h2>
       <b-form-input v-model="loginEmail" type="email" placeholder="Email" class="mb-3" />
@@ -108,11 +108,6 @@ async function login() {
 
 <style scoped lang="scss">
 @import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
-.popup-wrapper {
-  width: 360px;
-  margin: 0 auto;
-  font-family: 'Roboto', 'Open Sans', sans-serif;
-}
 .auth-card {
   border-radius: 0.75rem;
 }

--- a/frontend/src/pages/Register.vue
+++ b/frontend/src/pages/Register.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup-wrapper d-flex align-items-center justify-content-center">
+  <div class="popup-wrapper">
     <b-card class="auth-card shadow-sm">
       <h2 class="text-center mb-4">Cadastre-se</h2>
       <b-form-input v-model="registerUsername" placeholder="Usuário" class="mb-3" />
@@ -92,11 +92,6 @@ async function registerUser() {
 
 <style scoped lang="scss">
 @import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
-.popup-wrapper {
-  width: 360px;
-  margin: 0 auto;
-  font-family: 'Roboto', 'Open Sans', sans-serif;
-}
 .auth-card {
   border-radius: 0.75rem;
 }

--- a/frontend/src/ready/App.vue
+++ b/frontend/src/ready/App.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="ready-wrapper container mx-auto d-flex align-items-center justify-content-center">
-    <b-card class="text-center">
+  <div class="popup-wrapper ready-wrapper">
+    <b-card class="text-center dashboard-card">
       <h2>Pronto! Agora é só resumir as coisas 😎</h2>
       <b-button variant="outline-primary" class="mt-3" @click="irParaDashboard">
         Alterar API Key
@@ -20,8 +20,6 @@ function irParaDashboard() {
 
 <style scoped>
 .ready-wrapper {
-  max-width: 400px;
-  margin: auto;
   animation: fadeIn 0.5s ease;
 }
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- unify popup layout width rules in global stylesheet
- remove redundant wrapper styles from pages
- add `dashboard-card` class to standardize card widths
- make all pages use the shared `.popup-wrapper` container

## Testing
- `npm test` in `frontend`
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_6854b20061dc8324a87f0c128709f8ae